### PR TITLE
Fix computer tool result bug

### DIFF
--- a/tools/computer.py
+++ b/tools/computer.py
@@ -294,7 +294,7 @@ def invoke(input_data):
         logging.info(f"input_data: {input_data}")
         computer = ComputerTool()
         response = asyncio.run(computer(**input_data))
-        tool_result_content = {}
+        tool_result_content = {"json": {}}
         if response.error:
             tool_result_content["json"]["Error"] = response.error
         if response.output:


### PR DESCRIPTION
## Summary
- ensure `invoke` in computer tool initializes `json` sub-dict before assigning

## Testing
- `python -m py_compile tools/computer.py`

------
https://chatgpt.com/codex/tasks/task_e_68468c5136f08322ae84fed7169965d4